### PR TITLE
 Restrict API info to authorized users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@
 DATABASE_URL=
 
 # JWT_SECRET is used to add an extra layer of protection to user information in the token.
+# When a token is generated, the JWT_SECRET is used to add some text at the end which only the server can recognize.
+# This means that if someone sends in a token with a different JWT_SECRET value it won't get accepted.
 JWT_SECRET=
 
-# JWT_LIFETIME is used to restrict the use of a token to a given time period. After the time provided has passed, the user is required to re-authenticate themselves
+# JWT_LIFETIME is used to restrict the use of a token to a given time period. After the time provided has passed, the user is required to re-authenticate themselves.
 JWT_LIFETIME=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 # DATABASE_URL is used to connect to an external database of which this project will use.
 DATABASE_URL=
+
+# JWT_SECRET is used to add an extra layer of protection to user information in the token.
+JWT_SECRET=
+
+# JWT_LIFETIME is used to restrict the use of a token to a given time period. After the time provided has passed, the user is required to re-authenticate themselves
+JWT_LIFETIME=

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import express, { json, urlencoded } from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import authMiddleware from "./middleware/authRoute.js";
 import authRoutes from "./routes/auth/index.js";
 import apiRoutes from "./routes/api/index.js";
 
@@ -34,7 +35,7 @@ app.get("/", (req, res) => {
 });
 
 app.use("/auth", authRoutes);
-app.use("/api", apiRoutes);
+app.use("/api", authMiddleware, apiRoutes);
 
 // Starts the API on port 3000. E.g., http://localhost:3000.
 app.listen(3000, () => {

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import express, { json, urlencoded } from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import authRoutes from "./routes/auth/index.js";
 import apiRoutes from "./routes/api/index.js";
 
 const setXContentTypeOptions = (req, res, next) => {
@@ -32,6 +33,7 @@ app.get("/", (req, res) => {
     res.send("Welcome to the GTS homepage!");
 });
 
+app.use("/auth", authRoutes);
 app.use("/api", apiRoutes);
 
 // Starts the API on port 3000. E.g., http://localhost:3000.

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -48,6 +48,13 @@ const login = async (req, res) => {
     const contentType = req.headers["content-type"];
     if (!contentType || contentType !== "application/json")
       return res.status(400).json({ "msg": "Invalid Content-Type. Expected 'application/json'." });
+
+    // Check if the requested user exists before attempting to login
+    let user = await prisma.user.findUnique({
+      "where": { "name": String(req.body.name) },
+    });
+
+    if (!user) return res.status(409).json({ "msg": "Invalid username or password." });
   } catch (error) {
     
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -11,7 +11,12 @@ const register = async (req, res) => {
     if (!contentType || contentType !== "application/json")
       return res.status(400).json({ "msg": "Invalid Content-Type. Expected 'application/json'." });
 
-    
+    const user = await prisma.user.findUnique({
+      "where": { "name": String(req.body.name) },
+    });
+
+    if (user) return res.status(409).json({ "msg": "User already exists." });
+
   } catch (error) {
     return res.status(500).json({ "msg": error.message });
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -60,6 +60,11 @@ const login = async (req, res) => {
     // Since the password in the db is encrypted, it needs to compare it to the hashed password and check if the passwords are the same
     const isPasswordCorrect = await bcryptjs.compare(req.body.password, user.password);
     if (!isPasswordCorrect) return res.status(401).json({ "msg": "Invalid username or password." });
+
+    const token = jwt.sign({
+      "id": user.id,
+      "name": user.name,
+    }, process.env.JWT_SECRET, { "expiresIn": process.env.JWT_LIFETIME });
   } catch (error) {
     
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -55,6 +55,11 @@ const login = async (req, res) => {
     });
 
     if (!user) return res.status(401).json({ "msg": "Invalid username or password." });
+
+    // Check if the supplied password matches the request user's password
+    // Since the password in the db is encrypted, it needs to compare it to the hashed password and check if the passwords are the same
+    const isPasswordCorrect = await bcryptjs.compare(req.body.password, user.password);
+    if (!isPasswordCorrect) return res.status(401).json({ "msg": "Invalid username or password." });
   } catch (error) {
     
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -36,6 +36,7 @@ const register = async (req, res) => {
       "data": user,
     });
   } catch (error) {
+    // If an error occurs during the register process, return with a 500 status code and the error message generated.
     return res.status(500).json({ 
       "msg": error.message,
     });
@@ -63,6 +64,7 @@ const login = async (req, res) => {
 
     delete user.password;
 
+    // If all checks pass, generate new token with the user's name and id
     const token = jwt.sign({
       "id": user.id,
       "name": user.name,
@@ -70,11 +72,13 @@ const login = async (req, res) => {
 
     user.token = token;
 
+    // If token generation was successfully, return the user with the new token
     return res.status(200).json({
       "msg": `User ${user.name} successfully logged in!`,
       "data": user,
     });
   } catch (error) {
+    // If an error occurs during the login process, return with a 500 status code and the error message generated.
     return res.status(500).json({ 
       "msg": error.message,
     });

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -54,7 +54,7 @@ const login = async (req, res) => {
       "where": { "name": String(req.body.name) },
     });
 
-    if (!user) return res.status(409).json({ "msg": "Invalid username or password." });
+    if (!user) return res.status(401).json({ "msg": "Invalid username or password." });
   } catch (error) {
     
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -17,6 +17,9 @@ const register = async (req, res) => {
 
     if (user) return res.status(409).json({ "msg": "User already exists." });
 
+    const salt = await bcryptjs.genSalt();
+    const hashedPassword = await bcryptjs.hash(req.body.password, salt);
+    req.body.password = hashedPassword;
   } catch (error) {
     return res.status(500).json({ "msg": error.message });
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -11,7 +11,7 @@ const register = async (req, res) => {
     if (!contentType || contentType !== "application/json")
       return res.status(400).json({ "msg": "Invalid Content-Type. Expected 'application/json'." });
 
-    const user = await prisma.user.findUnique({
+    let user = await prisma.user.findUnique({
       "where": { "name": String(req.body.name) },
     });
 
@@ -20,6 +20,11 @@ const register = async (req, res) => {
     const salt = await bcryptjs.genSalt();
     const hashedPassword = await bcryptjs.hash(req.body.password, salt);
     req.body.password = hashedPassword;
+
+    user = await prisma.user.create({
+      "data": { ...req.body },
+    });
+    delete user.password;
   } catch (error) {
     return res.status(500).json({ "msg": error.message });
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -43,7 +43,14 @@ const register = async (req, res) => {
 };
 
 const login = async (req, res) => {
-
+  try {
+    // Check if the request is formatted correctly
+    const contentType = req.headers["content-type"];
+    if (!contentType || contentType !== "application/json")
+      return res.status(400).json({ "msg": "Invalid Content-Type. Expected 'application/json'." });
+  } catch (error) {
+    
+  }
 };
 
 export {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -6,6 +6,11 @@ const prisma = new PrismaClient();
 
 const register = async (req, res) => {
   try {
+    // Check if the request is formatted correctly
+    const contentType = req.headers["content-type"];
+    if (!contentType || contentType !== "application/json")
+      return res.status(400).json({ "msg": "Invalid Content-Type. Expected 'application/json'." });
+
     
   } catch (error) {
     return res.status(500).json({ "msg": error.message });

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -61,10 +61,19 @@ const login = async (req, res) => {
     const isPasswordCorrect = await bcryptjs.compare(req.body.password, user.password);
     if (!isPasswordCorrect) return res.status(401).json({ "msg": "Invalid username or password." });
 
+    delete user.password;
+
     const token = jwt.sign({
       "id": user.id,
       "name": user.name,
     }, process.env.JWT_SECRET, { "expiresIn": process.env.JWT_LIFETIME });
+
+    user.token = token;
+
+    return res.status(200).json({
+      "msg": `User ${user.name} successfully logged in!`,
+      "data": user,
+    });
   } catch (error) {
     
   }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -5,7 +5,11 @@ import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 
 const register = async (req, res) => {
-
+  try {
+    
+  } catch (error) {
+    return res.status(500).json({ "msg": error.message });
+  }
 };
 
 const login = async (req, res) => {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -16,7 +16,7 @@ const register = async (req, res) => {
       "where": { "name": String(req.body.name) },
     });
 
-    if (user) return res.status(409).json({ "msg": "User already exists." });
+    if (user) return res.status(409).json({ "msg": `User ${req.body.name} already exists.` });
 
     // Encrypt the user's password with a salt and a hash
     // The salt means that the hash is always different even if the password is the same as another user

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,0 +1,18 @@
+import bcryptjs from "bcryptjs";
+import jwt from "jsonwebtoken";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const register = async (req, res) => {
+
+};
+
+const login = async (req, res) => {
+
+};
+
+export {
+  register,
+  login
+};

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -75,7 +75,9 @@ const login = async (req, res) => {
       "data": user,
     });
   } catch (error) {
-    
+    return res.status(500).json({ 
+      "msg": error.message,
+    });
   }
 };
 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -25,8 +25,15 @@ const register = async (req, res) => {
       "data": { ...req.body },
     });
     delete user.password;
+
+    return res.status(201).json({
+      "msg": `User ${user.name} successfully created!`,
+      "data": user,
+    });
   } catch (error) {
-    return res.status(500).json({ "msg": error.message });
+    return res.status(500).json({ 
+      "msg": error.message,
+    });
   }
 };
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -92,6 +92,10 @@ const getUser = async (req, res) => {
 
 const updateUser = async (req, res) => {
   try {
+    // Check if the request is being made by a valid user.
+    if (!(req.user.id === req.params.id || req.user.name === req.params.id))
+      return res.status(403).json({ "msg": "Not authorized to make this request." });
+
     // Check if the request is using the correct format for the API to parse.
     const contentType = req.headers["content-type"];
     if (!contentType || contentType !== "application/json")
@@ -130,6 +134,10 @@ const updateUser = async (req, res) => {
 
 const deleteUser = async (req, res) => {
   try {
+    // Check if the request is being made by a valid user.
+    if (!(req.user.id === req.params.id || req.user.name === req.params.id))
+      return res.status(403).json({ "msg": "Not authorized to make this request." });
+    
     // Get the requested user.
     const queryUser = await prisma.user.findMany({
       // Search for a user with either an id or name that matches the id parameter.

--- a/middleware/authRoute.js
+++ b/middleware/authRoute.js
@@ -1,0 +1,11 @@
+import jwt from "jsonwebtoken";
+
+const authRoute = (req, res, next) => {
+  try {
+    
+  } catch (error) {
+    return res.status(403).json({ "msg": "Not authorized to access this route." });
+  }
+};
+
+export default authRoute;

--- a/middleware/authRoute.js
+++ b/middleware/authRoute.js
@@ -2,7 +2,10 @@ import jwt from "jsonwebtoken";
 
 const authRoute = (req, res, next) => {
   try {
-    
+    // Check if a valid token has been provided
+    const authHeader = req.headers["authorization"];
+    if (!authHeader || !authHeader.startsWith("Bearer"))
+      return res.status(403).json({ "msg": "No token provided." });
   } catch (error) {
     return res.status(403).json({ "msg": "Not authorized to access this route." });
   }

--- a/middleware/authRoute.js
+++ b/middleware/authRoute.js
@@ -11,10 +11,18 @@ const authRoute = (req, res, next) => {
     const token = authHeader.split(" ")[1];
     const payload = jwt.verify(token, process.env.JWT_SECRET);
 
-    req.user = payload; // Save the received user payload from the token to the request
+    // Save the received user payload from the token to the request
+    // E.g., 
+    // {
+    //    "id": "...",
+    //    "name": "...",
+    // }
+    req.user = payload; 
 
+    // If all checks passed and the payload was saved, allow the request to continue
     return next();
   } catch (error) {
+    // Return an invalid access error if an error occured during the validation process
     return res.status(403).json({ "msg": "Not authorized to access this route." });
   }
 };

--- a/middleware/authRoute.js
+++ b/middleware/authRoute.js
@@ -6,6 +6,14 @@ const authRoute = (req, res, next) => {
     const authHeader = req.headers["authorization"];
     if (!authHeader || !authHeader.startsWith("Bearer"))
       return res.status(403).json({ "msg": "No token provided." });
+
+    // Check if the token is valid in the API
+    const token = authHeader.split(" ")[1];
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+
+    req.user = payload; // Save the received user payload from the token to the request
+
+    return next();
   } catch (error) {
     return res.status(403).json({ "msg": "Not authorized to access this route." });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^5.15.0",
+        "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "nodemon": "^3.1.3",
@@ -117,6 +119,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -173,6 +180,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -333,6 +345,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -669,6 +689,86 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -967,7 +1067,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "^5.15.0",
+    "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.3",

--- a/routes/auth/index.js
+++ b/routes/auth/index.js
@@ -1,0 +1,5 @@
+import express from "express";
+
+const router = express.Router();
+
+export default router;

--- a/routes/auth/index.js
+++ b/routes/auth/index.js
@@ -1,5 +1,9 @@
 import express from "express";
+import { register, login } from "../../controllers/auth.js";
 
 const router = express.Router();
+
+router.post("/register", register);
+router.post("login", login);
 
 export default router;

--- a/routes/auth/index.js
+++ b/routes/auth/index.js
@@ -4,6 +4,6 @@ import { register, login } from "../../controllers/auth.js";
 const router = express.Router();
 
 router.post("/register", register);
-router.post("login", login);
+router.post("/login", login);
 
 export default router;


### PR DESCRIPTION
## Issue
Currently, anyone with the link to the API can create and manipulate information in the database. This means that player data is unprotected from a potential bad apple or even an accident from another player. To ensure that players are protected properly, the API should require an authorized user to access any information and only specific users can access more personal information (e.g., the player themselves, admins, etc.). Closes #17

## User Story
As a developer, I want to limit API information to authorized users, so that game information is more secure. 

## Requirements
* Register a new user
* Login to a user
  * Save relevant user info to a token and return it with the user
* Restrict access to API to users only
  * Check for valid token
* Require certain authorization levels when updating and deleting users
  * For now, only the same user can update or delete their user

## Testing
To test this pull request, you will need valid `.env` variables. The required variables are in a `.env.example` file which can be replicated as the required `.env` file. Put a message in the discord when testing and I will reply with the required values.

[Here is a link](https://gts666.postman.co/workspace/GTS-Workspace~a300bbab-0554-497c-80af-d1741de34a06/collection/29640716-b78a8b72-083e-4463-8176-8f54c7947366?action=share&creator=29640716) to a Postman collection with all of the relevant requests set up. You may be required to fork the collection to change and run the requests which will require a Postman account. Once you have successfully logged in to the API, assign the token generated in the response to the `token` variable in the main `GTS` collection tab.