### PR TITLE
Limit user requests

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -67,7 +67,6 @@ const login = async (req, res) => {
     // If all checks pass, generate new token with the user's name and id
     const token = jwt.sign({
       "id": user.id,
-      "name": user.name,
     }, process.env.JWT_SECRET, { "expiresIn": process.env.JWT_LIFETIME });
 
     user.token = token;

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -93,7 +93,7 @@ const getUser = async (req, res) => {
 const updateUser = async (req, res) => {
   try {
     // Check if the request is being made by a valid user.
-    if (!(req.user.id === req.params.id || req.user.name === req.params.id))
+    if (!(req.user.id === req.params.id))
       return res.status(403).json({ "msg": "Not authorized to make this request." });
 
     // Check if the request is using the correct format for the API to parse.
@@ -101,14 +101,9 @@ const updateUser = async (req, res) => {
     if (!contentType || contentType !== "application/json")
       return res.status(400).json({ "msg": "Invalid Content-Type. Expected 'application/json'." });
     
-    // Get the requested user by the id/name.
-    let user = await prisma.user.findFirst({
-      "where": {
-        "OR": [
-          { "id": { "equals": String(req.params.id) }},
-          { "name": { "equals": String(req.params.id) }},
-        ],
-      },
+    // Get the requested user by the id.
+    let user = await prisma.user.findUnique({
+      "where": { "id": String(req.params.id) },
     });
 
     // Check if the user exists, if not return a 404 not found response.
@@ -116,7 +111,7 @@ const updateUser = async (req, res) => {
 
     // Update the user with the provided information.
     user = await prisma.user.update({
-      "where": { "name": String(user.name) },
+      "where": { "id": String(user.id) },
       "data": { ...req.body },
     });
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -130,20 +130,13 @@ const updateUser = async (req, res) => {
 const deleteUser = async (req, res) => {
   try {
     // Check if the request is being made by a valid user.
-    if (!(req.user.id === req.params.id || req.user.name === req.params.id))
+    if (!(req.user.id === req.params.id))
       return res.status(403).json({ "msg": "Not authorized to make this request." });
     
     // Get the requested user.
-    const queryUser = await prisma.user.findMany({
-      // Search for a user with either an id or name that matches the id parameter.
-      "where": {
-        "OR": [
-          { "id": { "equals": String(req.params.id) }},
-          { "name": { "equals": String(req.params.id) }},
-        ],
-      },
+    const user = await prisma.user.findUnique({
+      "where": { "id": String(req.params.id) },
     });
-    const user = queryUser[0];
 
     // Check if the requested user exists, if not return a 404 not found response.
     if (!user) return res.status(404).json({ "msg": `User '${req.params.id}' not found.` });

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -59,14 +59,9 @@ const getUsers = async (req, res) => {
 
 const getUser = async (req, res) => {
   try {
-    const queryUser = await prisma.user.findMany({
-      // Search for a user with either an id or name that matches the id parameter.
-      "where": {
-        "OR": [
-          { "id": { "equals": String(req.params.id) }},
-          { "name": { "equals": String(req.params.id) }},
-        ],
-      },
+    const user = await prisma.user.findUnique({
+      // Search for a user that matches the id parameter.
+      "where": { "id": String(req.params.id) },
       // Only requests information that isn't confidential or dangerous.
       "select": {
         "id": true,
@@ -74,7 +69,6 @@ const getUser = async (req, res) => {
         "name": true,
       },
     });
-    const user = queryUser[0]; // Since findMany returns a list, take the first result. This should always work since the id and name fields require unique entries.
 
     // If the user doesn't exist, return a 404 not found response.
     if (!user) return res.status(404).json({ "msg": `User '${req.params.id}' not found.` });


### PR DESCRIPTION
## User Story
As a developer, I want to limit specific user requests to only use a user's id, so that user requests are always the same.

## Issue
Currently, a user has the choice to make user requests using their id or name as the search. This is nice for the user as it gives them the flexibility to use either for the same request. However, if a user changes their name, another user can no longer access the original information unless they know their id or new name. So, to avoid confusion, we need to limit the requests to use only the id because the id can't be changed. Closes #20

## Requirements
* Remove name from user requests
* Remove name from access token