### PR TITLE
Fix broken create invalid user test

### DIFF
--- a/test/00-user.test.js
+++ b/test/00-user.test.js
@@ -63,7 +63,7 @@ describe("Users", () => {
         money: 20
       })
       .end((req, res) => {
-        chai.expect(res.body.msg).to.be.equal("Argument `name`: Invalid value provided. Expected String, provided Int.");
+        chai.expect(res.body.msg).to.be.equal("Name should be a string.");
         done();
       });
   });


### PR DESCRIPTION
## WARNING!
This branch should be merged after #33 has been merged. Most of the code this fix is reliant on originates from that branch and will not work without it.

## Issue
Due to a lack of validation on user requests, invalid information sent to the API would result in an error that is lengthy and unhelpful. This made it difficult to test if attempting to create an user with invalid information would respond with an expected error message. Since validation has since been added, this test can be fixed.